### PR TITLE
Fix repository location of VoidLinux and display all versions

### DIFF
--- a/scrapers/voidlinux.js
+++ b/scrapers/voidlinux.js
@@ -3,15 +3,15 @@ var request = require('../lib/rxrequest');
 var filelisting = require('../lib/sites/filelisting');
 
 module.exports = function (_, cb) {
-  filelisting.getEntries('https://repo.voidlinux.eu/live/current/')
+  filelisting.getEntries('https://alpha.de.repo.voidlinux.org/live/current/')
     .filter(entry => entry.type === 'file')
     .map(entry => {
-      const match = /^void-live-(i686)-(\d{8})(?:-\w+)?\.iso$/g.exec(entry.name)
+      const match = /^void-live-(i686|x86_64)-(?:(?:(musl)-)?(\d{4,})(\d{2})(\d{2})(?:-(\w+))?)\.iso$/g.exec(entry.name)
       if (!match) return null
       return {
         url: entry.url,
         arch: match[1],
-        version: match[2]
+        version: `${match[6] ? `${match[6]} ` : ''}(${match[2] ? `${match[2]} ` : ''}${match[3]}-${match[4]}-${match[5]})`
       }
     })
     .filter(entry => entry)


### PR DESCRIPTION
VoidLinux had recently moved from voidlinux.eu to voidlinux.org, also does this PR add support for 64-bit images and more details about the iso in the version